### PR TITLE
JBSnorro 0.0.11

### DIFF
--- a/BlaTeX.csproj
+++ b/BlaTeX.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
 		<!-- Reference JBSnorro locally in DEBUG, otherwise use Nuget package.-->
-		<PackageReference Include="JBSnorro" Version="0.0.10" Condition="'$(Configuration)'!='Debug'" />
+		<PackageReference Include="JBSnorro" Version="0.0.11" Condition="'$(Configuration)'!='Debug'" />
 		<Reference Include="JBSnorro" Condition="'$(Configuration)'=='Debug'">
 			<HintPath>..\ASDE\JBSnorro\bin\Debug\net6.0\JBSnorro.dll</HintPath>
 		</Reference>

--- a/Tests/BlaTeX.Tests.csproj
+++ b/Tests/BlaTeX.Tests.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<ProjectReference Include="../BlaTeX.csproj" />
 		<!-- Reference JBSnorro locally in DEBUG, otherwise use Nuget package.-->
-		<PackageReference Include="JBSnorro" Version="0.0.10" Condition="'$(Configuration)'!='Debug'" />
+		<PackageReference Include="JBSnorro" Version="0.0.11" Condition="'$(Configuration)'!='Debug'" />
 		<Reference Include="JBSnorro" Condition="'$(Configuration)'=='Debug'">
 			<HintPath>..\..\ASDE\JBSnorro\bin\Debug\net6.0\JBSnorro.dll</HintPath>
 		</Reference>

--- a/Tests/Program.cs
+++ b/Tests/Program.cs
@@ -1,6 +1,9 @@
+using JBSnorro.Diagnostics;
+using JBSnorro.Extensions;
 using JBSnorro.Testing;
 using JBSnorro.Threading;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -31,10 +34,10 @@ namespace BlaTeX.Tests
 			}
 			else
 			{
+				// HelperToFindTestTypes(args);
 				TestExtensions.DefaultMainTestProjectImplementation(args);
 			}
 		}
-
 		public static string RootFolder
 		{
 			get
@@ -47,6 +50,28 @@ namespace BlaTeX.Tests
 						throw new InvalidOperationException("Cannot find project root folder");
 				}
 				return dir.FullName;
+			}
+		}
+
+		internal static void HelperToFindTestTypes(IReadOnlyList<string> args)
+		{
+			Contract.Requires(args.Count != 0);
+
+			string filter = args[0];
+			var types = typeof(Program).Assembly
+									   .GetTypes()
+									   .Where(type => type.Namespace.Contains("BlaTeX"))
+									   .Where(type => !type.Name.StartsWith("<"))
+									   .Where(type => type.FullName.Contains(filter, StringComparison.OrdinalIgnoreCase))
+									   .ToList();
+
+			if (types.Count == 0)
+				Console.WriteLine($"No types in this assembly have speakable names matching '{filter}'.");
+			foreach (Type type in types.OrderBy(t => t.FullName.Substring(t.Namespace.Length + ".".Length)))
+			{
+				string name = type.FullName.Substring(type.Namespace.Length + ".".Length);
+				int testCount = TestExtensions.GetTestMethods(type).Count();
+				Console.WriteLine($"{name} has {testCount} tests");
 			}
 		}
 	}

--- a/Tests/Program.cs
+++ b/Tests/Program.cs
@@ -21,7 +21,7 @@ namespace BlaTeX.Tests
 				var syncContext = new XunitAsyncTestSyncContext(null); // new Nito.AsyncEx.AsyncContext().SynchronizationContext
 				using (syncContext.AsTemporarySynchronizationContext())
 				{
-					TestExtensions.DefaultMainTestProjectImplementation(args);
+					await TestExtensions.DefaultMainTestProjectImplementation(args);
 				}
 				var exception = await syncContext.WaitForCompletionAsync();
 
@@ -35,7 +35,7 @@ namespace BlaTeX.Tests
 			else
 			{
 				// HelperToFindTestTypes(args);
-				TestExtensions.DefaultMainTestProjectImplementation(args);
+				await TestExtensions.DefaultMainTestProjectImplementation(args);
 			}
 		}
 		public static string RootFolder


### PR DESCRIPTION
This tracks everything that can only be merged on version 0.0.11 of library JBSnorro, once it gets pushed to nuget.org.